### PR TITLE
Make sure to perform replacements in key

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,6 +17,9 @@ export interface ILocaleTranslation {
 export interface ITranslation {
     [key: string]: string;
 }
+export interface IReplacement {
+    [Key: string]: string | number;
+}
 /**
  * Inits the configuration parameters and fetches the translations
  * @param conf ITranslateConfig configuration for the library
@@ -32,12 +35,11 @@ export declare const fetchTranslations: () => Promise<boolean>;
  * @param locale Optional locale to only return part of translations
  */
 export declare const exportTranslations: (locale?: string | undefined) => ILocaleTranslation | ITranslation | undefined;
+export declare const getLocales: () => string[] | undefined;
 /**
  * Translates a given phrase using replacements and a locale
  * @param key phrase to translate
  * @param replacements optional replacements as key/value object
  * @param locale optional locale to use for translations
  */
-export declare const t: (key: string, replacements?: {
-    [Key: string]: string | number;
-} | undefined, context?: string | undefined, locale?: string | undefined) => string;
+export declare const t: (key: string, replacements?: IReplacement | undefined, context?: string | undefined, locale?: string | undefined) => string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -78,6 +78,12 @@ exports.exportTranslations = (locale) => {
         return translations;
     }
 };
+exports.getLocales = () => {
+    if (translations) {
+        return Object.keys(translations);
+    }
+    return undefined;
+};
 /**
  * Translates a given phrase using replacements and a locale
  * @param key phrase to translate
@@ -87,29 +93,29 @@ exports.exportTranslations = (locale) => {
 exports.t = (key, replacements, context, locale) => {
     if (!translations) {
         logError(`No translations were available to client`);
-        return key;
+        return replaceParams(key, replacements);
     }
     if (!locale) {
         if (!configuration.locale) {
             logError(`No locale specified when looking up key: ${key}`);
-            return key;
+            return replaceParams(key, replacements);
         }
         locale = configuration.locale;
     }
     if (!translations.hasOwnProperty(locale)) {
         logError(`Missing locale: "${locale}" in translations`);
-        return key;
+        return replaceParams(key, replacements);
     }
     let processedKey = context ? `${key}<${context}>` : key;
     if (!translations[locale].hasOwnProperty(processedKey)) {
         if (!context) {
             logError(`Missing translation for locale: "${locale}" with key: "${key}"`);
-            return key;
+            return replaceParams(key, replacements);
         }
         // If a context was provided, we check if a translation is available for the key without context
         if (!translations[locale].hasOwnProperty(key)) {
             logError(`Missing translation for locale: "${locale}" with key: "${key}" and context: "${context}"`);
-            return key;
+            return replaceParams(key, replacements);
         }
         else {
             // We found a translation by not using the context
@@ -118,11 +124,17 @@ exports.t = (key, replacements, context, locale) => {
         }
     }
     let result = translations[locale][processedKey];
-    if (replacements) {
-        for (const key in replacements) {
-            if (replacements.hasOwnProperty(key)) {
-                result = result.replace(`%${key}`, `${replacements[key]}`);
-            }
+    result = replaceParams(result, replacements);
+    return result;
+};
+const replaceParams = (phrase, replacements) => {
+    if (!replacements) {
+        return phrase;
+    }
+    let result = phrase;
+    for (const key in replacements) {
+        if (replacements.hasOwnProperty(key)) {
+            result = result.replace(`%${key}`, `${replacements[key]}`);
         }
     }
     return result;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,11 @@
 import { mockResponseOnce } from 'jest-fetch-mock'
-import { exportTranslations, initTranslations, t, ITranslateConfig } from '.'
+import {
+  exportTranslations,
+  initTranslations,
+  t,
+  ITranslateConfig,
+  getLocales,
+} from '.'
 import {
   mockTranslations,
   nonExistingPhrase,
@@ -10,6 +16,8 @@ import {
   contextValue,
   noContextKey,
   noContextValue,
+  nonExistingTokenPhrase,
+  locale,
 } from '../test/setupJest'
 
 const customErrorCallback = jest.fn(e => {
@@ -69,4 +77,20 @@ test('An invalid translation should return original phrase also when adding a co
   )
   errorCalls++
   expect(customErrorCallback).toHaveBeenCalledTimes(errorCalls)
+})
+
+test('Correctly replaces words in a non existing phrase', () => {
+  const replacements = {
+    num1: 4,
+    num2: '3',
+  }
+  expect(t(nonExistingTokenPhrase, replacements)).toEqual(
+    `You have ${replacements.num1} new contracts with ${
+      replacements.num2
+    } missing options`,
+  )
+})
+
+test('Returns the correct list of locales', () => {
+  expect(getLocales()).toEqual([locale])
 })

--- a/test/setupJest.ts
+++ b/test/setupJest.ts
@@ -7,6 +7,8 @@ export const translatableKey = 'Contract template'
 export const translatableValue = 'Kontrakt type'
 export const tokenKey = 'You have %num1 unread messages and %num2 notifications'
 export const tokenValue = 'Du har %num1 ulæste beskeder og %num2 notifikationer'
+export const nonExistingTokenPhrase =
+  'You have %num1 new contracts with %num2 missing options'
 export const nonExistingPhrase = 'This phrase is not translatable'
 export const context = 'Dialog'
 export const contextKey = `Cancel<${context}>`


### PR DESCRIPTION
If a translation is not found, the `t` function will still apply
replacements in the key. Also added a utility function for exporting
all locales.